### PR TITLE
Twiki twiki twiki

### DIFF
--- a/_includes/css/base.css
+++ b/_includes/css/base.css
@@ -281,6 +281,4 @@ button:hover {
 }
 code[class*="language-"], pre[class*="language-"] {
 font-family: "Reddit Mono", Consolas, Courier, monospace;
-    color:#000;
-    text-shadow: none;
 }

--- a/_includes/css/base.css
+++ b/_includes/css/base.css
@@ -279,3 +279,8 @@ button:hover {
     white-space: nowrap;
     border: 0;
 }
+code[class*="language-"], pre[class*="language-"] {
+font-family: "Reddit Mono", Consolas, Courier, monospace;
+    color:#000;
+    text-shadow: none;
+}

--- a/_includes/css/tw.css
+++ b/_includes/css/tw.css
@@ -1772,6 +1772,10 @@ video {
   max-width: 65ch;
 }
 
+.flex-auto {
+  flex: 1 1 auto;
+}
+
 .flex-grow {
   flex-grow: 1;
 }

--- a/_includes/css/tw.css
+++ b/_includes/css/tw.css
@@ -1699,6 +1699,10 @@ video {
   margin-top: 1.5rem;
 }
 
+.mb-3 {
+  margin-bottom: 0.75rem;
+}
+
 .block {
   display: block;
 }
@@ -2007,6 +2011,10 @@ video {
 
 .leading-8 {
   line-height: 2rem;
+}
+
+.leading-6 {
+  line-height: 1.5rem;
 }
 
 .text-blue-400 {

--- a/_includes/css/tw.css
+++ b/_includes/css/tw.css
@@ -2186,4 +2186,8 @@ video {
   .lg\:grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
+
+  .lg\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
 }

--- a/_includes/css/tw.css
+++ b/_includes/css/tw.css
@@ -1639,6 +1639,10 @@ video {
   float: right;
 }
 
+.clear-left {
+  clear: left;
+}
+
 .mx-2 {
   margin-left: 0.5rem;
   margin-right: 0.5rem;
@@ -1657,6 +1661,11 @@ video {
 .my-6 {
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
+}
+
+.my-3 {
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
 }
 
 .mb-0 {
@@ -1701,6 +1710,10 @@ video {
 
 .mb-3 {
   margin-bottom: 0.75rem;
+}
+
+.mt-3 {
+  margin-top: 0.75rem;
 }
 
 .block {
@@ -2161,6 +2174,10 @@ video {
 
   .sm\:grid-cols-4 {
     grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .sm\:grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
   }
 }
 

--- a/_includes/css/tw.css
+++ b/_includes/css/tw.css
@@ -1248,14 +1248,6 @@ video {
   max-width: 12rem;
 }
 
-.max-w-4xl {
-  max-width: 56rem;
-}
-
-.max-w-prose {
-  max-width: 65ch;
-}
-
 .flex-grow {
   flex-grow: 1;
 }

--- a/_includes/css/tw.css
+++ b/_includes/css/tw.css
@@ -1093,6 +1093,500 @@ video {
   margin-bottom: 0;
 }
 
+.prose-lg {
+  font-size: 1.125rem;
+  line-height: 1.7777778;
+}
+
+.prose-lg :where(p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+  margin-bottom: 1.3333333em;
+}
+
+.prose-lg :where([class~="lead"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 1.2222222em;
+  line-height: 1.4545455;
+  margin-top: 1.0909091em;
+  margin-bottom: 1.0909091em;
+}
+
+.prose-lg :where(blockquote):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.6666667em;
+  margin-bottom: 1.6666667em;
+  padding-inline-start: 1em;
+}
+
+.prose-lg :where(h1):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 2.6666667em;
+  margin-top: 0;
+  margin-bottom: 0.8333333em;
+  line-height: 1;
+}
+
+.prose-lg :where(h2):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 1.6666667em;
+  margin-top: 1.8666667em;
+  margin-bottom: 1.0666667em;
+  line-height: 1.3333333;
+}
+
+.prose-lg :where(h3):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 1.3333333em;
+  margin-top: 1.6666667em;
+  margin-bottom: 0.6666667em;
+  line-height: 1.5;
+}
+
+.prose-lg :where(h4):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.7777778em;
+  margin-bottom: 0.4444444em;
+  line-height: 1.5555556;
+}
+
+.prose-lg :where(img):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.7777778em;
+  margin-bottom: 1.7777778em;
+}
+
+.prose-lg :where(picture):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.7777778em;
+  margin-bottom: 1.7777778em;
+}
+
+.prose-lg :where(picture > img):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.prose-lg :where(video):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.7777778em;
+  margin-bottom: 1.7777778em;
+}
+
+.prose-lg :where(kbd):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.8888889em;
+  border-radius: 0.3125rem;
+  padding-top: 0.2222222em;
+  padding-inline-end: 0.4444444em;
+  padding-bottom: 0.2222222em;
+  padding-inline-start: 0.4444444em;
+}
+
+.prose-lg :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.8888889em;
+}
+
+.prose-lg :where(h2 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.8666667em;
+}
+
+.prose-lg :where(h3 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.875em;
+}
+
+.prose-lg :where(pre):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.8888889em;
+  line-height: 1.75;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  border-radius: 0.375rem;
+  padding-top: 1em;
+  padding-inline-end: 1.5em;
+  padding-bottom: 1em;
+  padding-inline-start: 1.5em;
+}
+
+.prose-lg :where(ol):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+  margin-bottom: 1.3333333em;
+  padding-inline-start: 1.5555556em;
+}
+
+.prose-lg :where(ul):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+  margin-bottom: 1.3333333em;
+  padding-inline-start: 1.5555556em;
+}
+
+.prose-lg :where(li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.6666667em;
+  margin-bottom: 0.6666667em;
+}
+
+.prose-lg :where(ol > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0.4444444em;
+}
+
+.prose-lg :where(ul > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0.4444444em;
+}
+
+.prose-lg :where(.prose-lg > ul > li p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.8888889em;
+  margin-bottom: 0.8888889em;
+}
+
+.prose-lg :where(.prose-lg > ul > li > p:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+}
+
+.prose-lg :where(.prose-lg > ul > li > p:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-bottom: 1.3333333em;
+}
+
+.prose-lg :where(.prose-lg > ol > li > p:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+}
+
+.prose-lg :where(.prose-lg > ol > li > p:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-bottom: 1.3333333em;
+}
+
+.prose-lg :where(ul ul, ul ol, ol ul, ol ol):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.8888889em;
+  margin-bottom: 0.8888889em;
+}
+
+.prose-lg :where(dl):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+  margin-bottom: 1.3333333em;
+}
+
+.prose-lg :where(dt):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+}
+
+.prose-lg :where(dd):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.6666667em;
+  padding-inline-start: 1.5555556em;
+}
+
+.prose-lg :where(hr):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 3.1111111em;
+  margin-bottom: 3.1111111em;
+}
+
+.prose-lg :where(hr + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose-lg :where(h2 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose-lg :where(h3 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose-lg :where(h4 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose-lg :where(table):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.8888889em;
+  line-height: 1.5;
+}
+
+.prose-lg :where(thead th):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-end: 0.75em;
+  padding-bottom: 0.75em;
+  padding-inline-start: 0.75em;
+}
+
+.prose-lg :where(thead th:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0;
+}
+
+.prose-lg :where(thead th:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-end: 0;
+}
+
+.prose-lg :where(tbody td, tfoot td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-top: 0.75em;
+  padding-inline-end: 0.75em;
+  padding-bottom: 0.75em;
+  padding-inline-start: 0.75em;
+}
+
+.prose-lg :where(tbody td:first-child, tfoot td:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0;
+}
+
+.prose-lg :where(tbody td:last-child, tfoot td:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-end: 0;
+}
+
+.prose-lg :where(figure):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.7777778em;
+  margin-bottom: 1.7777778em;
+}
+
+.prose-lg :where(figure > *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.prose-lg :where(figcaption):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.8888889em;
+  line-height: 1.5;
+  margin-top: 1em;
+}
+
+.prose-lg :where(.prose-lg > :first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose-lg :where(.prose-lg > :last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-bottom: 0;
+}
+
+.prose-2xl {
+  font-size: 1.5rem;
+  line-height: 1.6666667;
+}
+
+.prose-2xl :where(p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+  margin-bottom: 1.3333333em;
+}
+
+.prose-2xl :where([class~="lead"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 1.25em;
+  line-height: 1.4666667;
+  margin-top: 1.0666667em;
+  margin-bottom: 1.0666667em;
+}
+
+.prose-2xl :where(blockquote):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.7777778em;
+  margin-bottom: 1.7777778em;
+  padding-inline-start: 1.1111111em;
+}
+
+.prose-2xl :where(h1):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 2.6666667em;
+  margin-top: 0;
+  margin-bottom: 0.875em;
+  line-height: 1;
+}
+
+.prose-2xl :where(h2):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 2em;
+  margin-top: 1.5em;
+  margin-bottom: 0.8333333em;
+  line-height: 1.0833333;
+}
+
+.prose-2xl :where(h3):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 1.5em;
+  margin-top: 1.5555556em;
+  margin-bottom: 0.6666667em;
+  line-height: 1.2222222;
+}
+
+.prose-2xl :where(h4):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.6666667em;
+  margin-bottom: 0.6666667em;
+  line-height: 1.5;
+}
+
+.prose-2xl :where(img):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose-2xl :where(picture):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose-2xl :where(picture > img):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.prose-2xl :where(video):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose-2xl :where(kbd):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.8333333em;
+  border-radius: 0.375rem;
+  padding-top: 0.25em;
+  padding-inline-end: 0.3333333em;
+  padding-bottom: 0.25em;
+  padding-inline-start: 0.3333333em;
+}
+
+.prose-2xl :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.8333333em;
+}
+
+.prose-2xl :where(h2 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.875em;
+}
+
+.prose-2xl :where(h3 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.8888889em;
+}
+
+.prose-2xl :where(pre):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.8333333em;
+  line-height: 1.8;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  border-radius: 0.5rem;
+  padding-top: 1.2em;
+  padding-inline-end: 1.6em;
+  padding-bottom: 1.2em;
+  padding-inline-start: 1.6em;
+}
+
+.prose-2xl :where(ol):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+  margin-bottom: 1.3333333em;
+  padding-inline-start: 1.5833333em;
+}
+
+.prose-2xl :where(ul):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+  margin-bottom: 1.3333333em;
+  padding-inline-start: 1.5833333em;
+}
+
+.prose-2xl :where(li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+.prose-2xl :where(ol > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0.4166667em;
+}
+
+.prose-2xl :where(ul > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0.4166667em;
+}
+
+.prose-2xl :where(.prose-2xl > ul > li p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.8333333em;
+  margin-bottom: 0.8333333em;
+}
+
+.prose-2xl :where(.prose-2xl > ul > li > p:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+}
+
+.prose-2xl :where(.prose-2xl > ul > li > p:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-bottom: 1.3333333em;
+}
+
+.prose-2xl :where(.prose-2xl > ol > li > p:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+}
+
+.prose-2xl :where(.prose-2xl > ol > li > p:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-bottom: 1.3333333em;
+}
+
+.prose-2xl :where(ul ul, ul ol, ol ul, ol ol):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.6666667em;
+  margin-bottom: 0.6666667em;
+}
+
+.prose-2xl :where(dl):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+  margin-bottom: 1.3333333em;
+}
+
+.prose-2xl :where(dt):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.3333333em;
+}
+
+.prose-2xl :where(dd):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.5em;
+  padding-inline-start: 1.5833333em;
+}
+
+.prose-2xl :where(hr):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 3em;
+  margin-bottom: 3em;
+}
+
+.prose-2xl :where(hr + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose-2xl :where(h2 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose-2xl :where(h3 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose-2xl :where(h4 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose-2xl :where(table):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.8333333em;
+  line-height: 1.4;
+}
+
+.prose-2xl :where(thead th):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-end: 0.6em;
+  padding-bottom: 0.8em;
+  padding-inline-start: 0.6em;
+}
+
+.prose-2xl :where(thead th:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0;
+}
+
+.prose-2xl :where(thead th:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-end: 0;
+}
+
+.prose-2xl :where(tbody td, tfoot td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-top: 0.8em;
+  padding-inline-end: 0.6em;
+  padding-bottom: 0.8em;
+  padding-inline-start: 0.6em;
+}
+
+.prose-2xl :where(tbody td:first-child, tfoot td:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0;
+}
+
+.prose-2xl :where(tbody td:last-child, tfoot td:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-end: 0;
+}
+
+.prose-2xl :where(figure):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.prose-2xl :where(figure > *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.prose-2xl :where(figcaption):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-size: 0.8333333em;
+  line-height: 1.6;
+  margin-top: 1em;
+}
+
+.prose-2xl :where(.prose-2xl > :first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+
+.prose-2xl :where(.prose-2xl > :last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-bottom: 0;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/_includes/css/tw.css
+++ b/_includes/css/tw.css
@@ -1742,6 +1742,23 @@ video {
   max-width: 12rem;
 }
 
+.max-w-96 {
+  max-width: 24rem;
+}
+
+.max-w-none {
+  max-width: none;
+}
+
+.max-w-fit {
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+}
+
+.max-w-prose {
+  max-width: 65ch;
+}
+
 .flex-grow {
   flex-grow: 1;
 }

--- a/_includes/css/tw.css
+++ b/_includes/css/tw.css
@@ -1654,6 +1654,11 @@ video {
   margin-bottom: 0.5rem;
 }
 
+.my-6 {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
 .mb-0 {
   margin-bottom: 0px;
 }
@@ -1688,6 +1693,10 @@ video {
 
 .mt-8 {
   margin-top: 2rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
 }
 
 .block {
@@ -1895,6 +1904,16 @@ video {
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+}
+
+.bg-slate-600 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(71 85 105 / var(--tw-bg-opacity, 1));
+}
+
+.bg-slate-300 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(203 213 225 / var(--tw-bg-opacity, 1));
 }
 
 .p-2 {

--- a/_includes/layouts/contact.njk
+++ b/_includes/layouts/contact.njk
@@ -1,44 +1,39 @@
-<div class="grid grid-cols-1 md:grid-cols-2 gap-8 mt-0">
+<div class="grid grid-cols-1 md:grid-cols-2mt-0 not-prose">
     {# Left Column: Calendar #}
-    <div class="order-1 md:order-1 h-full">
-        <div class="bg-white p-6 rounded-lg shadow-md h-full">
-            <h2 class="text-2xl font-bold mb-4">Schedule a meeting</h2>
-            <p class="mb-4 text-gray-600">Choose a time to discuss your content strategy needs.</p>
-            <iframe
+    <div class="order-1 md:order-1 rounded-lg shadow-md">
+        <h2 class="font-bold mb-4">Schedule a meeting</h2>
+        <p class="mb-4">Choose a time to discuss your content strategy needs.</p>
+        <iframe
                 src="https://calendar.google.com/calendar/appointments/schedules/AcZssZ1CBWdgGqhLcE1ESu06P0r2-035wBc_jmj5EITbEmOXP5Zir_405nPRA5dBDMDEyZzc-S8AeI4D?gv=true"
-                class="w-full h-[600px] border-0">
-            </iframe>
-        </div>
+                class="w-full h-[600px] border-0"></iframe>
     </div>
 
     {# Right Column: Contact Form #}
-    <div class="order-2 md:order-2 h-full">
-        <div class="bg-white p-6 rounded-lg shadow-md h-full">
-            <h2 class="text-2xl font-bold mb-4">Send a message</h2>
-            <form class="space-y-4" name="contact" method="POST" data-netlify="true" netlify>
-                <input type="hidden" name="subject"
-  value="Yeh message" />
-                <div>
-                    <label for="name" class="block text-sm font-medium text-gray-700">Name</label>
-                    <input type="text" id="name" name="name" required
+    <div class="order-2 md:order-2 rounded-lg shadow-md ">
+        <h2 class="text-2xl font-bold mb-4">Send a message</h2>
+        <form class="space-y-4" name="contact" method="POST" data-netlify="true" netlify>
+            <input type="hidden" name="subject"
+  value="Yeh message"/>
+            <div>
+                <label for="name" class="block text-sm font-medium text-gray-700">Name</label>
+                <input type="text" id="name" name="name" required
                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                </div>
-                <div>
-                    <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
-                    <input type="email" id="email" name="email" required
+            </div>
+            <div>
+                <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
+                <input type="email" id="email" name="email" required
                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
-                </div>
-                <div>
-                    <label for="message" class="block text-sm font-medium text-gray-700">Message</label>
-                    <textarea id="message" name="message" rows="4" required
+            </div>
+            <div>
+                <label for="message" class="block text-sm font-medium text-gray-700">Message</label>
+                <textarea id="message" name="message" rows="4" required
                              class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"></textarea>
-                </div>
-                <button type="submit"
-                        class="w-full bg-medium-blue text-white py-2 px-4 rounded-md hover:bg-blue-700 transition-colors">
+            </div>
+            <button type="submit"
+                        class="w-full bg-medium-blue text-white rounded-md hover:bg-blue-700 transition-colors">
                     Send message
                 </button>
-            </form>
-        </div>
+        </form>
     </div>
 
     {# Full Width: Quick Connect Section #}

--- a/_includes/layouts/details.njk
+++ b/_includes/layouts/details.njk
@@ -1,14 +1,15 @@
 {% include 'layouts/partials/header.njk' %}
+
 {% if collectionName == "podcasts" %}
     <figure class="hero flex justify-end float-right ml-2">
         {% include 'layouts/partials/hero-image.njk' %}
     </figure>
 {% endif %}
-<div class="container prose">
+
     {% if content %}
         {{ content | markdown | safe }}
     {% endif %}
-</div>
+
     {% if collectionName == "podcasts" %}
         {% from "layouts/partials/macros.njk" import renderButton %}
         {{ renderButton(
@@ -21,5 +22,5 @@
 	<source src="/assets/podcasts/{{mp3File}}" type="audio/mp3">
 </audio>
     {% endif %}
-
+</article>
 {% include 'layouts/partials/footer.njk' %}

--- a/_includes/layouts/details.njk
+++ b/_includes/layouts/details.njk
@@ -10,6 +10,10 @@
     buttonText="Listen now",
     title=title + " podcast"
 ) }}
+
+<audio controls>
+	<source src="/assets/podcasts/{{mp3File}}" type="audio/ogg">
+</audio>
     {% endif %}
 {% endif %}
 <div class="container prose">

--- a/_includes/layouts/details.njk
+++ b/_includes/layouts/details.njk
@@ -3,22 +3,23 @@
     <figure class="hero flex justify-end float-right ml-2">
         {% include 'layouts/partials/hero-image.njk' %}
     </figure>
-    {% if collectionName == "podcasts" %}
-        {% from "layouts/partials/macros.njk" import renderButton %}
-        {{ renderButton(
-    url="/assets/podcasts/" + mp3File,
-    buttonText="Listen now",
-    title=title + " podcast"
-) }}
-
-<audio controls>
-	<source src="/assets/podcasts/{{mp3File}}" type="audio/ogg">
-</audio>
-    {% endif %}
 {% endif %}
 <div class="container prose">
     {% if content %}
         {{ content | markdown | safe }}
     {% endif %}
 </div>
+    {% if collectionName == "podcasts" %}
+        {% from "layouts/partials/macros.njk" import renderButton %}
+        {{ renderButton(
+    url="/assets/podcasts/" + mp3File,
+    buttonText="Download",
+    title=title + " podcast"
+) }}
+
+<audio controls>
+	<source src="/assets/podcasts/{{mp3File}}" type="audio/mp3">
+</audio>
+    {% endif %}
+
 {% include 'layouts/partials/footer.njk' %}

--- a/_includes/layouts/details.njk
+++ b/_includes/layouts/details.njk
@@ -17,6 +17,4 @@
         {{ content | markdown | safe }}
     {% endif %}
 </div>
-
-{% include 'layouts/partials/next-previous.njk' %}
 {% include 'layouts/partials/footer.njk' %}

--- a/_includes/layouts/details.njk
+++ b/_includes/layouts/details.njk
@@ -12,7 +12,7 @@
 ) }}
     {% endif %}
 {% endif %}
-<div class="container mx-auto">
+<div class="container prose">
     {% if content %}
         {{ content | markdown | safe }}
     {% endif %}

--- a/_includes/layouts/grid.njk
+++ b/_includes/layouts/grid.njk
@@ -1,6 +1,6 @@
 {% include "layouts/partials/header.njk" %}
 
-<div class="container grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2">
+<div class="container grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2">
     {% set collectionName = collectionName %}
     {% set filtered_collections = collections[collectionName] %}
     {% for item in filtered_collections %}

--- a/_includes/layouts/grid.njk
+++ b/_includes/layouts/grid.njk
@@ -1,6 +1,6 @@
 {% include "layouts/partials/header.njk" %}
 
-<div class="container grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+<div class="container grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2">
     {% set collectionName = collectionName %}
     {% set filtered_collections = collections[collectionName] %}
     {% for item in filtered_collections %}

--- a/_includes/layouts/partials/footer.njk
+++ b/_includes/layouts/partials/footer.njk
@@ -1,6 +1,9 @@
         </main>
 
-        <footer class="p-4 mt-2 mb-0 rounded-bl-md rounded-tl-2xl">
+        <footer class="container p-4 my-2 rounded-bl-md  shadow-md">
+                                {% if layout == "layouts/details.njk" %}
+                                {% include 'layouts/partials/next-previous.njk' %}
+                                {% endif %}
             <div id="copyright">&copy; 2008&ndash;{% year %} &mdash; Ed Marsh's Jerk Store</div>
         </footer>
     </body>

--- a/_includes/layouts/partials/footer.njk
+++ b/_includes/layouts/partials/footer.njk
@@ -1,8 +1,9 @@
 </main>
-{% if layout == "layouts/details.njk" %}
+
+<footer class="container p-4 rounded-md shadow-md my-6 flex flex-wrap bg-medium-blue">
+    {% if layout == "layouts/details.njk" %}
 {% include 'layouts/partials/next-previous.njk' %}
 {% endif %}
-<footer class="container p-4 my-2">
 <div id="copyright">&copy; 2008&ndash;{% year %} &mdash; Ed Marsh's Jerk Store</div>
 </footer>
 </div>

--- a/_includes/layouts/partials/footer.njk
+++ b/_includes/layouts/partials/footer.njk
@@ -1,10 +1,10 @@
-        </main>
-
-        <footer class="container p-4 my-2 rounded-bl-md  shadow-md">
-                                {% if layout == "layouts/details.njk" %}
-                                {% include 'layouts/partials/next-previous.njk' %}
-                                {% endif %}
-            <div id="copyright">&copy; 2008&ndash;{% year %} &mdash; Ed Marsh's Jerk Store</div>
-        </footer>
-    </body>
+</main>
+{% if layout == "layouts/details.njk" %}
+{% include 'layouts/partials/next-previous.njk' %}
+{% endif %}
+<footer class="container p-4 my-2">
+<div id="copyright">&copy; 2008&ndash;{% year %} &mdash; Ed Marsh's Jerk Store</div>
+</footer>
+</div>
+</body>
 </html>

--- a/_includes/layouts/partials/footer.njk
+++ b/_includes/layouts/partials/footer.njk
@@ -1,10 +1,10 @@
 </main>
 
-<footer class="container p-4 rounded-md shadow-md my-6 flex flex-wrap bg-medium-blue">
+<footer class="container p-2 rounded-md shadow-md flex flex-wrap bg-medium-blue">
     {% if layout == "layouts/details.njk" %}
-{% include 'layouts/partials/next-previous.njk' %}
+<p class="mb-3">{% include 'layouts/partials/next-previous.njk' %}</p>
 {% endif %}
-<div id="copyright">&copy; 2008&ndash;{% year %} &mdash; Ed Marsh's Jerk Store</div>
+<p id="copyright" class="mt-3 clear-left">&copy; 2008&ndash;{% year %} &mdash; Ed Marsh's Jerk Store</p>
 </footer>
 </div>
 </body>

--- a/_includes/layouts/partials/header.njk
+++ b/_includes/layouts/partials/header.njk
@@ -19,7 +19,6 @@
         <script src="https://kit.fontawesome.com/c6516df4d1.js" crossorigin="anonymous"></script>
     </head>
     <body class="bg-whitish container mx-auto">
-        <div class="">
             {% block nav %}
                 {% include 'layouts/partials/navbar.njk' %}
                 {% include 'layouts/partials/breadcrumb.njk' %}

--- a/_includes/layouts/partials/header.njk
+++ b/_includes/layouts/partials/header.njk
@@ -25,6 +25,7 @@
             {% endblock %}
             {% block content %}
                 <main>
+                    <article>
                     <h1 class="text-3xl font-bold mb-4">{{title or metadata.title}}</h1>
                     {% if layout == "layouts/details.njk" %}
                         <p class="text-sm font-sans text-gray-600 mb-4">Updated: {{ page.date.toDateString()}} | {{ 'text' | timeToRead }} read time</p>

--- a/_includes/layouts/partials/macros.njk
+++ b/_includes/layouts/partials/macros.njk
@@ -4,11 +4,11 @@
         <ul
         id="{{ id }}-submenu"
         class="absolute hidden shadow-md rounded-md bg-medium-blue dropdown-menu"
-        aria-labelledby="{{ id }}"
+        aria-label="drop-down menu for {{ label }}"
     >
             {% for item in items %}
                 <li class="list-none font-sans">
-                    <a href="{{ item.url | url }}" class="block px-4 py-2 hover:bg-gray-100">{{ item.data.title }}</a>
+                    <a aria-labelledby="{{item.data.title}}" href="{{ item.url | url }}" class="block px-4 py-2 hover:bg-gray-100">{{ item.data.title }}</a>
                 </li>
             {% endfor %}
         </ul>
@@ -16,14 +16,14 @@
 {% endmacro %}
 
 {% macro listItem(url, label) %}
-    <li class="list-none font-sans">
+    <li class="list-none font-sans" aria-labelledby="{{ label }}">
         <a href="{{ url }}">{{ label }}</a>
     </li>
 {% endmacro %}
 
 {% macro gridItem(item) %}
     <div class="bg-whitish p-4">
-        <h3>
+        <h3 aria-labelledby="{{ item.data.title }}">
             <a href="{{ item.url }}">{{ item.data.title | safe }}</a>
         </h3>
         <p>{{ item.data.description }}</p>

--- a/_includes/layouts/partials/macros.njk
+++ b/_includes/layouts/partials/macros.njk
@@ -37,6 +37,11 @@
         role="button"
         download="{{ mp3File }}"
         class="inline-block font-sans"
+        {% if title %}
+            aria-label="Learn more about {{ title }}"
+        {% else %}
+            aria-label="{{ buttonText }}"
+        {% endif %}
         title="{% if title %}Learn more about {{ title }}{% else %}{{ buttonText }}{% endif %}"
     >
             <button

--- a/_includes/layouts/partials/macros.njk
+++ b/_includes/layouts/partials/macros.njk
@@ -61,9 +61,8 @@
 {% endmacro %}
 
 {% macro card(url, title, description, buttonText, heroImage) %}
-    <article
+    <div
     class="card flex flex-col rounded-xl shadow-xl my-2 h-full border-gray-200 border-2 pt-4"
-    role="article"
     aria-labelledby="card-title-{{ title | slugify }}"
 >
         <figure class="hero flex justify-center items-center" role="img" aria-label="{% if heroImage %}Hero image for {{ title }}{% endif %}">
@@ -78,5 +77,5 @@
             </div>
             {{ renderButton(url, buttonText, title) }}
         </div>
-    </article>
+    </div>
 {% endmacro %}

--- a/_includes/layouts/partials/macros.njk
+++ b/_includes/layouts/partials/macros.njk
@@ -35,6 +35,7 @@
         <a
         href="{{ url }}"
         role="button"
+        download="{{ mp3File }}"
         class="inline-block font-sans"
         title="{% if title %}Learn more about {{ title }}{% else %}{{ buttonText }}{% endif %}"
     >

--- a/_includes/layouts/partials/navbar.njk
+++ b/_includes/layouts/partials/navbar.njk
@@ -1,6 +1,6 @@
 {% from "layouts/partials/macros.njk" import dropdown, listItem %}
 
-<nav class="container bg-green-blue mx-auto">
+<nav class="container bg-green-blue">
     <div class="space-y-4 px-4">
         <div class="text-xl">
             <span class="font-semibold text-whitish">Ed Marsh</span>

--- a/_includes/layouts/partials/navbar.njk
+++ b/_includes/layouts/partials/navbar.njk
@@ -1,6 +1,6 @@
 {% from "layouts/partials/macros.njk" import dropdown, listItem %}
 
-<nav class="container bg-green-blue">
+<nav class="container bg-green-blue" aria-label="Ed Marsh introduction and site navigation menu">
     <div class="space-y-4 px-4">
         <div class="text-xl">
             <span class="font-semibold text-whitish">Ed Marsh</span>

--- a/_includes/layouts/partials/next-previous.njk
+++ b/_includes/layouts/partials/next-previous.njk
@@ -2,10 +2,9 @@
     {% set previousPost = collections[collectionName] | getPreviousCollectionItem(item) %}
     {% set nextPost = collections[collectionName] | getNextCollectionItem(item) %}
     {% if previousPost %}
-        <div class="shadow-md p-2 rounded-sm ">
+        <div class="container p-4 rounded-md shadow-md my-6 flex flex-wrap bg-slate-300">
             <a href="{{ previousPost.url }}">
                 <span class="fa-solid fa-arrow-left-long"></span> Previous | {{ previousPost.data.title }}</a>
-
             {% if nextPost %}
                 <div class="float-right">
 

--- a/_includes/layouts/partials/next-previous.njk
+++ b/_includes/layouts/partials/next-previous.njk
@@ -2,16 +2,14 @@
     {% set previousPost = collections[collectionName] | getPreviousCollectionItem(item) %}
     {% set nextPost = collections[collectionName] | getNextCollectionItem(item) %}
     {% if previousPost %}
-        <div class="container p-4 rounded-md shadow-md my-6 flex flex-wrap bg-slate-300">
-            <a href="{{ previousPost.url }}">
-                <span class="fa-solid fa-arrow-left-long"></span> Previous | {{ previousPost.data.title }}</a>
+        <div class="leading-6 mb-3">
+            <span class="fa-solid fa-arrow-left-long text-grey-green"></span> Previous | <a href="{{ previousPost.url }}">{{ previousPost.data.title }}</a>
             {% if nextPost %}
                 <div class="float-right">
 
                     <a href="{{ nextPost.url }}">
-                        {{ nextPost.data.title }} | Next
-                    <span class="fa-solid fa-arrow-right-long"></a>
-                    </span>
+                        {{ nextPost.data.title }}</a> | Next
+                    <span class="fa-solid fa-arrow-right-long text-grey-green"></span>
                 </div>
             </div>
         {% endif %}

--- a/_includes/layouts/partials/next-previous.njk
+++ b/_includes/layouts/partials/next-previous.njk
@@ -2,7 +2,7 @@
     {% set previousPost = collections[collectionName] | getPreviousCollectionItem(item) %}
     {% set nextPost = collections[collectionName] | getNextCollectionItem(item) %}
     {% if previousPost %}
-        <div class="leading-6 mb-3">
+        <div class="leading-6">
             <span class="fa-solid fa-arrow-left-long text-grey-green"></span> <a href="{{ previousPost.url }}">Previous | {{ previousPost.data.title }}</a>
             {% if nextPost %}
                 <div class="float-right">

--- a/_includes/layouts/partials/next-previous.njk
+++ b/_includes/layouts/partials/next-previous.njk
@@ -3,12 +3,11 @@
     {% set nextPost = collections[collectionName] | getNextCollectionItem(item) %}
     {% if previousPost %}
         <div class="leading-6 mb-3">
-            <span class="fa-solid fa-arrow-left-long text-grey-green"></span> Previous | <a href="{{ previousPost.url }}">{{ previousPost.data.title }}</a>
+            <span class="fa-solid fa-arrow-left-long text-grey-green"></span> <a href="{{ previousPost.url }}">Previous | {{ previousPost.data.title }}</a>
             {% if nextPost %}
                 <div class="float-right">
-
                     <a href="{{ nextPost.url }}">
-                        {{ nextPost.data.title }}</a> | Next
+                        {{ nextPost.data.title }} | Next</a>
                     <span class="fa-solid fa-arrow-right-long text-grey-green"></span>
                 </div>
             </div>

--- a/content/technical-writing-examples/index.md
+++ b/content/technical-writing-examples/index.md
@@ -3,6 +3,7 @@ title : "Technical writing examples"
 description: This what Ed do.
 layout : layouts/grid.njk
 eleventyExcludeFromCollections : true
+FontAwesomeIcon: 'solid fa-hat-wizard'
 ---
 
 title : "Content Content Podcast: The people behind the content"

--- a/content/technical-writing-examples/technical-writing-examples.json
+++ b/content/technical-writing-examples/technical-writing-examples.json
@@ -3,5 +3,7 @@
     "collectionName": "examples",
     "layout": "layouts/details.njk",
     "tags": "examples",
-    "category": "Writing samples"
+    "category": "Writing samples",
+    "FontAwesomeIcon": "solid fa-hat-wizard"
+
 }

--- a/content/technical-writing-examples/technical-writing-examples.json
+++ b/content/technical-writing-examples/technical-writing-examples.json
@@ -3,7 +3,5 @@
     "collectionName": "examples",
     "layout": "layouts/details.njk",
     "tags": "examples",
-    "category": "Writing samples",
-    "FontAwesomeIcon": "solid fa-hat-wizard"
-
+    "category": "Writing samples"
 }

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -34,11 +34,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(syntaxHighlight, {
 
     // Change which Eleventy template formats use syntax highlighters
-    templateFormats: ["njk"], // default
-
-    // e.g. Use syntax highlighters in njk and md Eleventy templates (not liquid)
-    // templateFormats: ["njk", "md"],
-
+    templateFormats: ["njk", "md"], // default
 
     // Added in 3.0, set to true to always wrap lines in `<span class="highlight-line">`
     // The default (false) only wraps when line numbers are passed in.


### PR DESCRIPTION
This is a lot of little tweaks to things: 

- Moved the next-previous links section out of `<main>` and into the footer.
- Styled the footer.  Now next/prev and footer are in one container.
- Added an icon for writing samples.
- Played around with flex and prose.
- Moved grid pages to four-column layout for large screens.
- "Improved"(?)/simplified contact page
- Added label-by and labelled-by to menus for accessibility
- Inline mp3 player for podcast pages
- Listen button now downloads instead
- Changed cards so they each weren't an `<article>`