### PR TITLE
Sans-serif font swap from deprecated Poppins to Barlow

### DIFF
--- a/_includes/css/base.css
+++ b/_includes/css/base.css
@@ -391,6 +391,7 @@ footer>div>p>a {
 
 .pagefind-ui__form svelte-e9gkc3 {
     background-color: white;
+    z-index: 0;
 }
 
 /* * Dialog styles */

--- a/_includes/css/base.css
+++ b/_includes/css/base.css
@@ -18,7 +18,7 @@
     --pagefind-ui-shadow: 0;
     /* Fonts - Alphabetical */
     --monospace: "Reddit Mono", Consolas, Courier, monospace;
-    --sans-serif: "Poppins", Roboto, Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    --sans-serif: Barlow, Roboto, Ubuntu, 'Helvetica Neue', Helvetica, Arial, sans-serif;
     --serif: "Besley", serif;
 
     .bg-medium-blue,

--- a/_includes/css/base.css
+++ b/_includes/css/base.css
@@ -142,7 +142,7 @@ h2 {
 
 h2>a {
     font-family: var(--sans-serif);
-    font-size: 1.3rem;
+    font-size: 1.5rem;
     font-weight: 700;
     color: var(--medium-blue)
 }
@@ -172,8 +172,8 @@ ol li {
 p {
     color: #000;
     font-family: var(--serif);
-    font-size: 1.1rem;
-    line-height: 1.6rem;
+    font-size: 0.9rem;
+    line-height: 1.4rem;
     margin: 0.75rem 0
 }
 
@@ -387,6 +387,10 @@ footer>div>p>a {
 
 #searchToggle {
     transition: color 0.2s ease-out;
+}
+
+.pagefind-ui__form svelte-e9gkc3 {
+    background-color: white;
 }
 
 /* * Dialog styles */

--- a/_includes/css/base.css
+++ b/_includes/css/base.css
@@ -389,7 +389,7 @@ footer>div>p>a {
     transition: color 0.2s ease-out;
 }
 
-.pagefind-ui__form svelte-e9gkc3, .pagefind-ui__drawer svelte-e9gkc3, .pagefind-ui__results-area svelte-e9gkc3, .pagefind-ui__results svelte-e9gkc3 {
+.pagefind-ui__form svelte-e9gkc3, .pagefind-ui__drawer svelte-e9gkc3, .pagefind-ui__results-area svelte-e9gkc3, .pagefind-ui__results svelte-e9gkc3, .pagefind-ui--reset {
     background-color: green;
 }
 

--- a/_includes/css/base.css
+++ b/_includes/css/base.css
@@ -389,8 +389,8 @@ footer>div>p>a {
     transition: color 0.2s ease-out;
 }
 
-.pagefind-ui__form svelte-e9gkc3, .pagefind-ui__drawer svelte-e9gkc3, .pagefind-ui__results-area svelte-e9gkc3, .pagefind-ui__results svelte-e9gkc3, .pagefind-ui--reset {
-    background-color: green;
+.pagefind-ui--reset {
+    background-color: white;
 }
 
 

--- a/_includes/css/base.css
+++ b/_includes/css/base.css
@@ -133,7 +133,7 @@ h1 {
 
 h2 {
     font-family: var(--sans-serif);
-    font-size: 1.3rem;
+    font-size: 1.5rem;
     font-weight: 700;
     margin-top: 1rem;
     margin-bottom: 0.5rem;
@@ -172,7 +172,7 @@ ol li {
 p {
     color: #000;
     font-family: var(--serif);
-    font-size: 104%;
+    font-size: 1.1rem;
     line-height: 1.6rem;
     margin: 0.75rem 0
 }

--- a/_includes/css/base.css
+++ b/_includes/css/base.css
@@ -389,8 +389,8 @@ footer>div>p>a {
     transition: color 0.2s ease-out;
 }
 
-.pagefind-ui__form svelte-e9gkc3, .pagefind-ui__drawer svelte-e9gkc3 {
-    background-color: white;
+.pagefind-ui__form svelte-e9gkc3, .pagefind-ui__drawer svelte-e9gkc3, .pagefind-ui__results-area svelte-e9gkc3, .pagefind-ui__results svelte-e9gkc3 {
+    background-color: green;
 }
 
 

--- a/_includes/css/base.css
+++ b/_includes/css/base.css
@@ -389,10 +389,10 @@ footer>div>p>a {
     transition: color 0.2s ease-out;
 }
 
-.pagefind-ui__form svelte-e9gkc3 {
+.pagefind-ui__form svelte-e9gkc3, .pagefind-ui__drawer svelte-e9gkc3 {
     background-color: white;
-    z-index: 0;
 }
+
 
 /* * Dialog styles */
 dialog.image-dialog {

--- a/_includes/layouts/partials/header.njk
+++ b/_includes/layouts/partials/header.njk
@@ -66,7 +66,7 @@
         </title>
         <link rel="icon" href="/assets/images/favicon.ico">
         <link rel="stylesheet" href="https://indestructibletype.com/fonts/Besley.css" type="text/css" charset="utf-8"/>
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous">
 <link href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Reddit+Mono:wght@200..900&display=swap" rel="stylesheet">
         <link rel="canonical" href="https://edmar.sh{{ page.url }}"/>
         <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet"/>

--- a/_includes/layouts/partials/header.njk
+++ b/_includes/layouts/partials/header.njk
@@ -66,7 +66,7 @@
         </title>
         <link rel="icon" href="/assets/images/favicon.ico">
         <link rel="stylesheet" href="https://indestructibletype.com/fonts/Besley.css" type="text/css" charset="utf-8"/>
-{# <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous"> #}
+<link rel="preconnect" href="https://fonts.gstatic.com">
 <link href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Reddit+Mono:wght@200..900&display=swap" rel="stylesheet">
         <link rel="canonical" href="https://edmar.sh{{ page.url }}"/>
         <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet"/>

--- a/_includes/layouts/partials/header.njk
+++ b/_includes/layouts/partials/header.njk
@@ -66,7 +66,7 @@
         </title>
         <link rel="icon" href="/assets/images/favicon.ico">
         <link rel="stylesheet" href="https://indestructibletype.com/fonts/Besley.css" type="text/css" charset="utf-8"/>
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous">
+{# <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous"> #}
 <link href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Reddit+Mono:wght@200..900&display=swap" rel="stylesheet">
         <link rel="canonical" href="https://edmar.sh{{ page.url }}"/>
         <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet"/>

--- a/_includes/layouts/partials/header.njk
+++ b/_includes/layouts/partials/header.njk
@@ -66,7 +66,8 @@
         </title>
         <link rel="icon" href="/assets/images/favicon.ico">
         <link rel="stylesheet" href="https://indestructibletype.com/fonts/Besley.css" type="text/css" charset="utf-8"/>
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@200..700&family=Reddit+Mono&display=swap">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Reddit+Mono:wght@200..900&display=swap" rel="stylesheet">
         <link rel="canonical" href="https://edmar.sh{{ page.url }}"/>
         <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet"/>
         <link rel="stylesheet" type="text/css" href="/css/tw.css">

--- a/_includes/layouts/partials/header.njk
+++ b/_includes/layouts/partials/header.njk
@@ -66,7 +66,7 @@
         </title>
         <link rel="icon" href="/assets/images/favicon.ico">
         <link rel="stylesheet" href="https://indestructibletype.com/fonts/Besley.css" type="text/css" charset="utf-8"/>
-<link rel="preconnect" href="https://fonts.gstatic.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Reddit+Mono:wght@200..900&display=swap" rel="stylesheet">
         <link rel="canonical" href="https://edmar.sh{{ page.url }}"/>
         <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet"/>

--- a/_includes/layouts/partials/navbar.njk
+++ b/_includes/layouts/partials/navbar.njk
@@ -25,7 +25,7 @@
                     <i class="fa-solid fa-search text-2xl"></i>
                     <span class="sr-only">Toggle search</span>
                 </button>
-                <div id="search" class="hidden absolute right-0 top-full mt-2 w-64 bg-whitish rounded-sm shadow-lg z-50"></div>
+                <div id="search" class="hidden absolute right-0 top-full mt-2 w-64 rounded-sm shadow-lg -z-10"></div>
             </li>
             {{ listItem('/contact/', 'Contact Ed') }}
         </ul>

--- a/_includes/layouts/partials/navbar.njk
+++ b/_includes/layouts/partials/navbar.njk
@@ -25,7 +25,7 @@
                     <i class="fa-solid fa-search text-2xl"></i>
                     <span class="sr-only">Toggle search</span>
                 </button>
-                <div id="search" class="hidden absolute right-0 top-full mt-2 w-64 rounded-sm shadow-lg -z-10"></div>
+                <div id="search" class="hidden absolute right-0 top-full mt-2 w-64 rounded-sm shadow-lg"></div>
             </li>
             {{ listItem('/contact/', 'Contact Ed') }}
         </ul>

--- a/netlify.toml
+++ b/netlify.toml
@@ -33,11 +33,10 @@
   to = "/contact"
 
 [[plugins]]
-package = "netlify-plugin-checklinks"
+  package = "netlify-plugin-checklinks"
   [plugins.inputs]
-  # Skip checks for Google Fonts domains that cause TLS/preconnect failures
-  ignoreUrls = [
-    "https://fonts.gstatic.com",
-    "https://fonts.gstatic.com/*",
-    "https://fonts.googleapis.com/*"
-  ]
+    skipPatterns = [
+      "https://fonts.gstatic.com",
+      "https://fonts.gstatic.com/*",
+      "https://fonts.googleapis.com/*"
+    ]

--- a/netlify.toml
+++ b/netlify.toml
@@ -31,3 +31,13 @@
 [[redirects]]
   from = "*contact-ed-marsh-information-architect-technical-writer"
   to = "/contact"
+
+[[plugins]]
+package = "netlify-plugin-checklinks"
+  [plugins.inputs]
+  # Skip checks for Google Fonts domains that cause TLS/preconnect failures
+  ignoreUrls = [
+    "https://fonts.gstatic.com",
+    "https://fonts.gstatic.com/*",
+    "https://fonts.googleapis.com/*"
+  ]


### PR DESCRIPTION
Poppins seems no longer available on Google Fonts. Replacing with Barlow.