### PR TITLE
🧹 [Code Health] Remove unused nunjucks configuration from eleventy.config.js

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -236,8 +236,3 @@ eleventyConfig.addFilter("shouldShowDate", function(page) {
     templateFormats: ["md", "njk", "html"], // File formats to process
   };
 };
-const nunjucks = require('nunjucks');
-const env = nunjucks.configure('views', {
-    lstripBlocks: true, // Automatically remove leading whitespace from blocks/tags
-    trimBlocks: true    // Automatically remove trailing newlines from blocks/tags
-});


### PR DESCRIPTION
**What:** Removed unused `nunjucks` variable and `env` configuration from `eleventy.config.js`.

**Why:** The 'nunjucks' variable and 'env' configuration were created but never exported or used anywhere in the configuration file. Removing them improves code maintainability and readability by eliminating dead code.

**Verification:** Built the site successfully using `npm run build` and ran tests using `npm run test`. Code changes were correctly verified by the agent. 

**Result:** A cleaner `eleventy.config.js` file with no unnecessary/unused configuration code, ensuring better code health.

---
*PR created automatically by Jules for task [19174147381686582](https://jules.google.com/task/19174147381686582) started by @emdashdrupal*