### PR TITLE
Exclude podcast landing page from homepage cards

### DIFF
--- a/_includes/layouts/partials/macros.njk
+++ b/_includes/layouts/partials/macros.njk
@@ -14,7 +14,12 @@
         <p class="description">{{ description | safe }}</p>
         <div class="grid lg:grid-cols-2 md:grid-cols-2 sm:grid-cols-1">
             {% if collectionName == "podcasts" %}
-                {% set itemsToShow = collections[collectionName] | sort(false, false, "data.date") | reverse %}
+                {% set itemsToShow = [] %}
+                {% for item in collections[collectionName] | sort(false, false, "data.date") | reverse %}
+                    {% if not item.inputPath or not item.inputPath.endsWith('/index.md') %}
+                        {% set itemsToShow = (itemsToShow.push(item), itemsToShow) %}
+                    {% endif %}
+                {% endfor %}
             {% else %}
                 {% set featured = collections[collectionName] | filterBy("data.featured", true) %}
                 {% set itemsToShow = featured | sort(false, false, "data.featuredOrder") %}

--- a/test-modularization.js
+++ b/test-modularization.js
@@ -44,6 +44,10 @@ try {
         {
             name: 'No unrendered Nunjucks syntax',
             check: () => !indexHtml.match(/\{\{[^}]*\}\}/) && !indexHtml.match(/\{%[^%]*%\}/)
+        },
+        {
+            name: 'No podcast landing page card on homepage',
+            check: () => !indexHtml.includes('card-title-content-content-podcast-the-people-behind-the-content')
         }
     ];
 


### PR DESCRIPTION
Modified the `featuredSection` macro in `_includes/layouts/partials/macros.njk` to filter out index pages from the podcasts collection. This prevents the podcast landing page from appearing as a card in the "Recent podcasts" section on the homepage. Added a corresponding regression test in `test-modularization.js`.

---
*PR created automatically by Jules for task [11088260017458599148](https://jules.google.com/task/11088260017458599148) started by @emdashdrupal*