### PR TITLE
🧹 optimize sitemap generation path lookup

### DIFF
--- a/generate-sitemap.js
+++ b/generate-sitemap.js
@@ -90,24 +90,32 @@ function getUrlFromFilePath(filePath) {
   return `/${urlPath}/`;
 }
 
-// Function to determine priority based on path
-function getPriority(url) {
+// Function to determine path configuration (priority and changefreq)
+function getPathConfig(url) {
   const config = pathConfigs.get(url);
-  if (config) return config.priority;
+
+  if (config) {
+    return {
+      priority: config.priority,
+      changefreq: config.changefreq
+    };
+  }
 
   const parts = url.split('/').filter(Boolean);
-  if (parts.length === 1) return defaultPriority.section;
-  if (parts.length === 2) return defaultPriority.page;
+  let priority;
 
-  return defaultPriority.post;
-}
+  if (parts.length === 1) {
+    priority = defaultPriority.section;
+  } else if (parts.length === 2) {
+    priority = defaultPriority.page;
+  } else {
+    priority = defaultPriority.post;
+  }
 
-// Function to determine change frequency
-function getChangeFreq(url) {
-  const config = pathConfigs.get(url);
-  if (config) return config.changefreq;
-
-  return defaultChangeFreq;
+  return {
+    priority,
+    changefreq: defaultChangeFreq
+  };
 }
 
 // Generate sitemap entries
@@ -126,8 +134,7 @@ function generateSitemapEntries() {
 
       const url = getUrlFromFilePath(file);
       const lastmod = getDateFromFile(file, data);
-      const priority = getPriority(url);
-      const changefreq = getChangeFreq(url);
+      const { priority, changefreq } = getPathConfig(url);
 
       if (!entriesMap.has(url) || entriesMap.get(url).lastmod < lastmod) {
         entriesMap.set(url, {

--- a/generate-sitemap.js
+++ b/generate-sitemap.js
@@ -20,14 +20,14 @@ const defaultPriority = {
 const today = new Date().toISOString().split('T')[0];
 
 // Configuration for specific paths to ensure they get the right priority and changefreq
-const pathConfigs = [
-  { path: '/', priority: defaultPriority.home, changefreq: 'monthly' },
-  { path: '/about/about-ed-marsh/', priority: defaultPriority.section, changefreq: 'monthly' },
-  { path: '/contact/', priority: defaultPriority.section, changefreq: 'monthly' },
-  { path: '/skills/', priority: defaultPriority.section, changefreq: 'monthly' },
-  { path: '/podcasts/', priority: defaultPriority.section, changefreq: 'monthly' },
-  { path: '/blog/', priority: defaultPriority.section, changefreq: 'weekly' }
-];
+const pathConfigs = new Map([
+  ['/', { priority: defaultPriority.home, changefreq: 'monthly' }],
+  ['/about/about-ed-marsh/', { priority: defaultPriority.section, changefreq: 'monthly' }],
+  ['/contact/', { priority: defaultPriority.section, changefreq: 'monthly' }],
+  ['/skills/', { priority: defaultPriority.section, changefreq: 'monthly' }],
+  ['/podcasts/', { priority: defaultPriority.section, changefreq: 'monthly' }],
+  ['/blog/', { priority: defaultPriority.section, changefreq: 'weekly' }]
+]);
 
 // Function to get last commit date from Git
 function getGitDate(filePath) {
@@ -92,9 +92,7 @@ function getUrlFromFilePath(filePath) {
 
 // Function to determine priority based on path
 function getPriority(url) {
-  if (url === '/') return defaultPriority.home;
-
-  const config = pathConfigs.find(c => c.path === url);
+  const config = pathConfigs.get(url);
   if (config) return config.priority;
 
   const parts = url.split('/').filter(Boolean);
@@ -106,7 +104,7 @@ function getPriority(url) {
 
 // Function to determine change frequency
 function getChangeFreq(url) {
-  const config = pathConfigs.find(c => c.path === url);
+  const config = pathConfigs.get(url);
   if (config) return config.changefreq;
 
   return defaultChangeFreq;


### PR DESCRIPTION
This change improves the performance and maintainability of the sitemap generation script by using a `Map` for path-specific configurations instead of repeatedly searching an array.

- **What:** Refactored `pathConfigs` in `generate-sitemap.js` to a `Map`.
- **Why:** To optimize lookups from $O(N)$ to $O(1)$ during the sitemap generation loop, improving both code health and performance.
- **Verification:**
    - Ran `npm run generate-sitemap` and confirmed the output `sitemap.xml` is identical to the pre-change version using `diff`.
    - Ran the full test suite (`npm test` and `npm run test:modular`) to ensure no regressions.
- **Result:** Cleaner code and more efficient sitemap generation.

---
*PR created automatically by Jules for task [16818728460103662848](https://jules.google.com/task/16818728460103662848) started by @emdashdrupal*