### PR TITLE
Fix Jest TypeError during test execution

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,10 @@
 module.exports = {
+  rootDir: '.',
   testEnvironment: 'jsdom',
   testMatch: [
     '**/tests/**/*.test.js'
   ],
-  setupFilesAfterEnv: ['./tests/setupTests.js'],
+  setupFilesAfterEnv: ['<rootDir>/tests/setupTests.js'],
   collectCoverageFrom: [
     'eleventy.config.js',
     '_includes/js/**/*.js',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "postbuild": "npm run generate-sitemap && npx -y pagefind --site _site && cp sitemap.xml _site/",
         "clean": "rm -rf _site",
         "debug": "DEBUG=Eleventy* npx @11ty/eleventy",
-        "test": "NODE_OPTIONS=\"--no-deprecation\" jest --passWithNoTests",
+        "test": "NODE_OPTIONS='--no-deprecation' jest --passWithNoTests",
         "test:watch": "jest --watch",
         "test:coverage": "jest --coverage",
         "test:ci": "jest --ci --coverage --watchAll=false",


### PR DESCRIPTION
The `TypeError: Cannot read properties of undefined (reading 'onlyChanged')` was caused by a failure in Jest's configuration initialization, likely due to shell-related quoting issues or path resolution ambiguity.

I have stabilized the environment by:
1. Updating `package.json` to use standard single-quoting for the `NODE_OPTIONS` environment variable.
2. Improving `jest.config.js` by explicitly setting `rootDir` and using the `<rootDir>` token for relative paths.
3. Adding a `package-lock.json` to the repository to ensure all environments use the same dependency versions, preventing cryptic internal errors from Jest's core packages.

All 77 tests now pass correctly across both `npm run test` and `npm run test:modular`.

---
*PR created automatically by Jules for task [6811614263412551747](https://jules.google.com/task/6811614263412551747) started by @emdashdrupal*