### PR TITLE
🧹 Improve error handling in filterBy filter

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -62,6 +62,8 @@ const postcssPlugins = [
 ];
 
 module.exports = function (eleventyConfig) {
+  const isDevelopment = process.env.ELEVENTY_RUN_MODE === 'serve' || process.env.NODE_ENV === 'test';
+
   // ===== HELPERS =====
   // Helper to normalize categories and check for matches
   const normalizeAndCheckCategories = (itemCategories, filterCategories) => {
@@ -109,7 +111,11 @@ module.exports = function (eleventyConfig) {
         return data == value; // Use loose equality for flexible value comparison
       });
     } catch (error) {
-      console.error(`Error in filterBy filter: ${error.message}`);
+      const errorMessage = `Error in filterBy filter (key: "${key}", value: "${value}"): ${error.message}`;
+      console.error(errorMessage);
+      if (isDevelopment) {
+        throw new Error(errorMessage);
+      }
       return [];
     }
   });

--- a/tests/filterBy.test.js
+++ b/tests/filterBy.test.js
@@ -56,7 +56,7 @@ describe('filterBy filter', () => {
     expect(filterBy(array, 'id', 1)).toEqual([{ id: 1 }, { id: '1' }]);
   });
 
-  test('handles errors gracefully', () => {
+  test('re-throws and logs errors in test environment', () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const array = [
       {
@@ -66,11 +66,55 @@ describe('filterBy filter', () => {
       }
     ];
 
-    const result = filterBy(array, 'data.test', true);
-
-    expect(result).toEqual([]);
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Error in filterBy filter: Test error'));
+    expect(() => filterBy(array, 'data.test', true)).toThrow('Error in filterBy filter (key: "data.test", value: "true"): Test error');
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Error in filterBy filter (key: "data.test", value: "true"): Test error'));
 
     consoleSpy.mockRestore();
+  });
+
+  test('handles errors gracefully in production environment', () => {
+    // Save original env
+    const originalRunMode = process.env.ELEVENTY_RUN_MODE;
+    const originalNodeEnv = process.env.NODE_ENV;
+
+    // Simulate production
+    process.env.ELEVENTY_RUN_MODE = 'build';
+    process.env.NODE_ENV = 'production';
+
+    // Re-initialize filter to pick up new env state
+    const mockEleventyConfig = {
+      addPlugin: jest.fn(),
+      addFilter: jest.fn(),
+      setLibrary: jest.fn(),
+      addTemplateFormats: jest.fn(),
+      addExtension: jest.fn(),
+      addTransform: jest.fn(),
+      addGlobalData: jest.fn(),
+      addShortcode: jest.fn(),
+      addPassthroughCopy: jest.fn(),
+      addCollection: jest.fn(),
+    };
+    eleventyConfigFn(mockEleventyConfig);
+    const prodFilterBy = mockEleventyConfig.addFilter.mock.calls.find(call => call[0] === 'filterBy')[1];
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const array = [
+      {
+        get data() {
+          throw new Error('Test error');
+        }
+      }
+    ];
+
+    const result = prodFilterBy(array, 'data.test', true);
+
+    expect(result).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Error in filterBy filter (key: "data.test", value: "true"): Test error'));
+
+    consoleSpy.mockRestore();
+
+    // Restore original env
+    process.env.ELEVENTY_RUN_MODE = originalRunMode;
+    process.env.NODE_ENV = originalNodeEnv;
   });
 });


### PR DESCRIPTION
🎯 **What:** Enhanced the `filterBy` filter in `eleventy.config.js` to provide better error logging and conditional re-throwing.
- Updated the error message to include the `key` and `value` that caused the error.
- Implemented environment detection using `process.env.ELEVENTY_RUN_MODE` and `process.env.NODE_ENV`.
- The filter now re-throws errors during development (`serve` mode) and testing (`test` mode) to improve visibility of issues.
- In production (`build` mode), it continues to fail gracefully by returning an empty array and logging the error.

💡 **Why:** Swallowing errors without sufficient context makes debugging difficult during development. Re-throwing in development ensures that developers are immediately aware of issues with their templates or data.

✅ **Verification:**
- Updated `tests/filterBy.test.js` to verify both the re-throwing behavior in tests and the graceful failure in simulated production.
- Ran `npm test tests/filterBy.test.js` (All 7 tests passed).
- Ran all project tests with `npm test` and `npm run test:modular` (All tests passed).

✨ **Result:** More maintainable and debuggable code without changing production behavior.

---
*PR created automatically by Jules for task [12278818351202805509](https://jules.google.com/task/12278818351202805509) started by @emdashdrupal*