### PR TITLE
🧪 Add unit tests for getDateFromFile in sitemap generator

### DIFF
--- a/generate-sitemap.js
+++ b/generate-sitemap.js
@@ -92,7 +92,7 @@ function getDateFromFile(filePath, data) {
     }
 
     // 2. Secondary: Git commit date (stable across checkouts)
-    const gitDate = getGitDate(filePath);
+    const gitDate = module.exports.getGitDate(filePath);
     if (gitDate) return gitDate;
 
     // 3. Fallback: File modification date

--- a/tests/getDateFromFile.test.js
+++ b/tests/getDateFromFile.test.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const sitemap = require('../generate-sitemap.js');
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  statSync: jest.fn()
+}));
+
+describe('getDateFromFile', () => {
+  const today = new Date().toISOString().split('T')[0];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(sitemap, 'getGitDate').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    sitemap.getGitDate.mockRestore();
+  });
+
+  it('prioritizes frontmatter date when it is a valid string', () => {
+    const data = { date: '2023-01-01' };
+    expect(sitemap.getDateFromFile('test.md', data)).toBe('2023-01-01');
+  });
+
+  it('prioritizes frontmatter date when it is a Date object', () => {
+    const data = { date: new Date(Date.UTC(2023, 5, 15)) };
+    expect(sitemap.getDateFromFile('test.md', data)).toBe('2023-06-15');
+  });
+
+  it('falls back to Git date if frontmatter date is missing', () => {
+    const data = {};
+    sitemap.getGitDate.mockReturnValue('2023-10-27');
+    expect(sitemap.getDateFromFile('test.md', data)).toBe('2023-10-27');
+  });
+
+  it('falls back to Git date if frontmatter date is "Last Modified"', () => {
+    const data = { date: 'Last Modified' };
+    sitemap.getGitDate.mockReturnValue('2023-10-27');
+    expect(sitemap.getDateFromFile('test.md', data)).toBe('2023-10-27');
+  });
+
+  it('falls back to Git date if frontmatter date is an invalid date string', () => {
+    const data = { date: 'not-a-date' };
+    sitemap.getGitDate.mockReturnValue('2023-10-27');
+    expect(sitemap.getDateFromFile('test.md', data)).toBe('2023-10-27');
+  });
+
+  it('falls back to fs.statSync mtime if Git date is unavailable', () => {
+    const data = {};
+    sitemap.getGitDate.mockReturnValue(null);
+    fs.statSync.mockReturnValue({ mtime: new Date(Date.UTC(2023, 4, 20)) });
+    expect(sitemap.getDateFromFile('test.md', data)).toBe('2023-05-20');
+  });
+
+  it('returns today as ultimate fallback on error', () => {
+    const data = {};
+    sitemap.getGitDate.mockImplementation(() => { throw new Error('git error'); });
+    // This will be caught by the try-catch in getDateFromFile
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(sitemap.getDateFromFile('test.md', data)).toBe(today);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Error processing date for test.md'));
+    consoleSpy.mockRestore();
+  });
+
+  it('handles errors in fs.statSync by returning today', () => {
+    const data = {};
+    sitemap.getGitDate.mockReturnValue(null);
+    fs.statSync.mockImplementation(() => { throw new Error('fs error'); });
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(sitemap.getDateFromFile('test.md', data)).toBe(today);
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -62,51 +62,6 @@ describe('Sitemap Generator', () => {
     });
   });
 
-  describe('getDateFromFile', () => {
-    it('prioritizes frontmatter date', () => {
-      const { getDateFromFile } = require('../generate-sitemap.js');
-      const data = { date: '2023-01-01' };
-      expect(getDateFromFile('test.md', data)).toBe('2023-01-01');
-    });
-
-    it('falls back to Git date if frontmatter date is missing', () => {
-      const { getDateFromFile } = require('../generate-sitemap.js');
-      const { execFileSync } = require('child_process');
-      const data = {};
-      execFileSync.mockReturnValue('DATE:2023-10-27\ntest.md\n');
-      expect(getDateFromFile('test.md', data)).toBe('2023-10-27');
-    });
-
-    it('falls back to Git date if frontmatter date is "Last Modified"', () => {
-      const { getDateFromFile } = require('../generate-sitemap.js');
-      const { execFileSync } = require('child_process');
-      const data = { date: 'Last Modified' };
-      execFileSync.mockReturnValue('DATE:2023-10-27\ntest.md\n');
-      expect(getDateFromFile('test.md', data)).toBe('2023-10-27');
-    });
-
-    it('falls back to fs.statSync mtime if Git date is unavailable', () => {
-      const { getDateFromFile } = require('../generate-sitemap.js');
-      const { execFileSync } = require('child_process');
-      const fs = require('fs');
-      const data = {};
-      execFileSync.mockImplementation(() => { throw new Error(); });
-      fs.statSync.mockReturnValue({ mtime: new Date('2023-05-20') });
-      expect(getDateFromFile('test.md', data)).toBe('2023-05-20');
-    });
-
-    it('returns today as ultimate fallback on error', () => {
-      const data = {};
-      const { execFileSync } = require('child_process');
-      execFileSync.mockImplementation(() => { throw new Error(); });
-      fs.statSync.mockImplementation(() => { throw new Error('stat error'); });
-
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      expect(getDateFromFile('test.md', data)).toBe(today);
-      consoleSpy.mockRestore();
-    });
-  });
-
   describe('getUrlFromFilePath', () => {
     it('handles standard markdown files', () => {
       expect(getUrlFromFilePath('content/blog/post.md')).toBe('/blog/post/');


### PR DESCRIPTION
This PR addresses the missing test file for the `getDateFromFile` function in `generate-sitemap.js`.

🎯 **What:**
- Introduced a dedicated test suite for `getDateFromFile` to ensure reliable date extraction for the sitemap.
- Refactored `generate-sitemap.js` to allow for clean mocking of internal function calls.

📊 **Coverage:**
The new tests cover:
- **Priority 1:** Valid frontmatter date (both string and Date object).
- **Priority 2:** Git commit date fallback (when frontmatter is missing, invalid, or set to 'Last Modified').
- **Priority 3:** Filesystem modification date (`fs.statSync`) fallback when Git data is unavailable.
- **Ultimate Fallback:** Defaulting to today's date on unexpected errors.

✨ **Result:**
Improved test coverage and reliability for the sitemap generation process, ensuring that the `lastmod` field in `sitemap.xml` is accurately determined from available metadata.

---
*PR created automatically by Jules for task [17061793615097719247](https://jules.google.com/task/17061793615097719247) started by @emdashdrupal*