### PR TITLE
Add dynamic Podcast RSS feed

### DIFF
--- a/content/podcasts/podcast.xml.njk
+++ b/content/podcasts/podcast.xml.njk
@@ -20,7 +20,7 @@ eleventyExcludeFromCollections: true
     <itunes:type>episodic</itunes:type>
     <itunes:owner>
       <itunes:name>{{ itunesName or "Ed Marsh" }}</itunes:name>
-      <itunes:email>{{ itunesEmail or "podcasts@edmarsh.com" }}</itunes:email>
+      <itunes:email>{{ itunesEmail or "ed@edmar.sh" }}</itunes:email>
     </itunes:owner>
     <itunes:explicit>{{ itunesExplicit or "no" }}</itunes:explicit>
     <itunes:image href="https://edmar.sh/assets/images/content-content-podcast-new-cover.png" />

--- a/content/podcasts/podcast.xml.njk
+++ b/content/podcasts/podcast.xml.njk
@@ -20,7 +20,7 @@ eleventyExcludeFromCollections: true
     <itunes:type>episodic</itunes:type>
     <itunes:owner>
       <itunes:name>{{ itunesName or "Ed Marsh" }}</itunes:name>
-      <itunes:email>{{ itunesEmail or "ed@edmar.sh" }}</itunes:email>
+      <itunes:email>{{ itunesEmail or "podcasts@edmarsh.com" }}</itunes:email>
     </itunes:owner>
     <itunes:explicit>{{ itunesExplicit or "no" }}</itunes:explicit>
     <itunes:image href="https://edmar.sh/assets/images/content-content-podcast-new-cover.png" />

--- a/content/podcasts/podcast.xml.njk
+++ b/content/podcasts/podcast.xml.njk
@@ -1,0 +1,49 @@
+---
+layout: false
+permalink: /podcasts/podcast.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+    xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+    xmlns:content="http://purl.org/rss/1.0/modules/content/"
+    xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <atom:link href="https://edmar.sh/podcasts/podcast.xml" rel="self" type="application/rss+xml" />
+    <title>{{ title or "Content Content podcast" }}</title>
+    <link>https://edmar.sh/podcasts/</link>
+    <description>{{ description }}</description>
+    <language>en</language>
+    <copyright>&#169; {% year %} Ed Marsh</copyright>
+    <itunes:author>{{ itunesAuthor or "Ed Marsh" }}</itunes:author>
+    <itunes:summary>{{ description }}</itunes:summary>
+    <itunes:type>episodic</itunes:type>
+    <itunes:owner>
+      <itunes:name>{{ itunesName or "Ed Marsh" }}</itunes:name>
+      <itunes:email>{{ itunesEmail or "ed@edmar.sh" }}</itunes:email>
+    </itunes:owner>
+    <itunes:explicit>{{ itunesExplicit or "no" }}</itunes:explicit>
+    <itunes:image href="https://edmar.sh/assets/images/content-content-podcast-new-cover.png" />
+    <itunes:category text="Technology" />
+    <itunes:category text="Business">
+      <itunes:category text="Marketing" />
+    </itunes:category>
+    {%- for post in collections.podcasts | reverse -%}
+    {%- if post.data.mp3File -%}
+    {%- set absolutePostUrl -%}https://edmar.sh{{ post.url | url }}{%- endset -%}
+    <item>
+      <title>{{ post.data.title }}</title>
+      <link>{{ absolutePostUrl }}</link>
+      <itunes:author>{{ itunesAuthor or "Ed Marsh" }}</itunes:author>
+      <itunes:summary>{{ post.data.description }}</itunes:summary>
+      <description>{{ post.data.description }}</description>
+      <content:encoded><![CDATA[{{ post.templateContent | safe }}]]></content:encoded>
+      <enclosure url="https://content.blubrry.com/contentcontent/{{ post.data.mp3File }}" length="0" type="audio/mpeg" />
+      <guid isPermaLink="false">{{ absolutePostUrl }}</guid>
+      <pubDate>{{ post.date.toUTCString() }}</pubDate>
+      <itunes:explicit>{{ post.data.itunesExplicit or "no" }}</itunes:explicit>
+    </item>
+    {%- endif -%}
+    {%- endfor -%}
+  </channel>
+</rss>

--- a/content/podcasts/podcasts.json
+++ b/content/podcasts/podcasts.json
@@ -7,6 +7,10 @@
   "category": "Podcasts",
   "categoryFontAwesomeIcon": "solid fa-podcast",
   "podHostID": "https://player.blubrry.com/id",
+  "itunesAuthor": "Ed Marsh",
+  "itunesName": "Ed Marsh",
+  "itunesEmail": "ed@edmar.sh",
+  "itunesExplicit": "no",
   "eleventyNavigation": {
     "key": "podcasts"
 }

--- a/content/podcasts/podcasts.json
+++ b/content/podcasts/podcasts.json
@@ -9,7 +9,7 @@
   "podHostID": "https://player.blubrry.com/id",
   "itunesAuthor": "Ed Marsh",
   "itunesName": "Ed Marsh",
-  "itunesEmail": "ed@edmar.sh",
+  "itunesEmail": "podcasts@edmarsh.com",
   "itunesExplicit": "no",
   "eleventyNavigation": {
     "key": "podcasts"

--- a/content/podcasts/podcasts.json
+++ b/content/podcasts/podcasts.json
@@ -9,7 +9,7 @@
   "podHostID": "https://player.blubrry.com/id",
   "itunesAuthor": "Ed Marsh",
   "itunesName": "Ed Marsh",
-  "itunesEmail": "podcasts@edmarsh.com",
+  "itunesEmail": "ed@edmar.sh",
   "itunesExplicit": "no",
   "eleventyNavigation": {
     "key": "podcasts"

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -265,7 +265,6 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({
     "assets/": "assets",
     "_includes/js": "js/",
-    "podcast.xml": "podcast.xml",
     "llms.txt": "llms.txt",
     "netlify.toml": "netlify.toml",
   });

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -273,7 +273,7 @@ module.exports = function (eleventyConfig) {
   const collections = ["skills", "podcasts", "blog"];
   collections.forEach((collection) => {
     eleventyConfig.addCollection(collection, (collectionApi) =>
-      collectionApi.getAll().filter((item) => item.data.tags?.includes(collection))
+      collectionApi.getFilteredByTag(collection)
     );
   });
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,10 @@
   to = "/podcasts"
 
 [[redirects]]
+  from = "/podcast.xml"
+  to = "/podcasts/podcast.xml"
+
+[[redirects]]
   from = "/content-content-podcast"
   to = "/podcasts"
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -72,7 +72,6 @@ describe('Eleventy Configuration', () => {
     expect(mockEleventyConfig.addPassthroughCopy).toHaveBeenCalledWith({
       "assets/": "assets",
       "_includes/js": "js/",
-      "podcast.xml": "podcast.xml",
       "llms.txt": "llms.txt",
       "netlify.toml": "netlify.toml",
     });


### PR DESCRIPTION
Implemented a dedicated, standards-compliant RSS feed for the "Content Content" podcast. The feed is dynamically generated from the podcast collection and includes all necessary metadata for platforms like Apple Podcasts, Spotify, and YouTube Music, such as iTunes categories, author information, and audio enclosures (hosted on Blubrry). Also included a redirect for the legacy feed path to ensure existing subscribers are not affected.

---
*PR created automatically by Jules for task [14240189013700394954](https://jules.google.com/task/14240189013700394954) started by @emdashdrupal*