### PR TITLE
🧹 Remove unused imports from sitemap.test.js

### DIFF
--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -17,9 +17,6 @@ jest.mock('fs', () => ({
 }));
 
 const {
-  loadGitDates,
-  getGitDate,
-  getDateFromFile,
   getUrlFromFilePath,
   getPriority,
   getChangeFreq


### PR DESCRIPTION
Removed three unused imported functions (`loadGitDates`, `getGitDate`, and `getDateFromFile`) from the top-level require statement of `tests/sitemap.test.js` to improve codebase cleanliness and maintainability. Verified with unit tests that all sitemap test cases continue to pass and function correctly.

---
*PR created automatically by Jules for task [5342132185041122517](https://jules.google.com/task/5342132185041122517) started by @emdashdrupal*