### PR TITLE
🧹 [code health improvement] Remove unused fs import from tests/sitemap.test.js

### DIFF
--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -1,5 +1,4 @@
 const { execFileSync } = require('child_process');
-const fs = require('fs');
 
 // We need to mock child_process before requiring generate-sitemap.js
 // because it might execute something if we are not careful


### PR DESCRIPTION
This pull request improves code maintainability and cleanliness by removing an unused `fs` import from `tests/sitemap.test.js`.

🎯 **What:** Removed `const fs = require('fs');` from the top of the `tests/sitemap.test.js` file.
💡 **Why:** The `fs` module was imported but never explicitly referenced or used in the file, resulting in dead code and possible linting warnings.
✅ **Verification:** Ran `npm run test` to confirm that all sitemap test cases (and the entire test suite) still pass cleanly without errors.
✨ **Result:** Enhanced code health, readability, and maintainability.

---
*PR created automatically by Jules for task [11511716466501762622](https://jules.google.com/task/11511716466501762622) started by @emdashdrupal*