### PR TITLE
🧹 Remove unused execFileSync import in tests/sitemap.test.js

### DIFF
--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -1,4 +1,3 @@
-const { execFileSync } = require('child_process');
 const fs = require('fs');
 
 // We need to mock child_process before requiring generate-sitemap.js


### PR DESCRIPTION
🎯 **What:** Removed the unused top-level require statement for `execFileSync` in `tests/sitemap.test.js`.
💡 **Why:** To improve codebase health, prevent any potential linting warnings, and keep the test suite cleaner and more readable.
✅ **Verification:** Verified that the entire Jest test suite (all 85 tests) runs and passes successfully.
✨ **Result:** A cleaner test file without any unused imports, keeping the codebase healthy and tidy.

---
*PR created automatically by Jules for task [3112788716002397997](https://jules.google.com/task/3112788716002397997) started by @emdashdrupal*